### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,6 @@
 name: Python Package using Conda
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/AnishVyapari/MylittleProject/security/code-scanning/1](https://github.com/AnishVyapari/MylittleProject/security/code-scanning/1)

To fix this problem, you need to add a `permissions` key to restrict the GitHub Actions workflow's default token permissions. The minimal baseline is to add `permissions: contents: read` at the workflow root, which restricts actions to only reading repository contents and does not allow writing to the repository, issues, or pull requests. This is sufficient unless a given job or step specifically needs more permission, which is not the case here. The change should be made at the top level of the workflow YAML (ideally after the `name:` and before `on:`), so that all jobs in the workflow inherit these restricted permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
